### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ If you want an angularjs version of their fillInAddress() function here is a goo
 $scope.placeSearch = "";
 $scope.autocomplete = "";
 
+//important to structure like this. $scope.location = "" wont work.
+$scope.data={"location":{}};
+
+$scope.googleChange = function(){
+  $scope.fillInAddress($scope.data.location);
+};
+  
+$scope.newCustomerData = {
+    street_addy : "", //addy 1
+    street_more : "", //addy 2
+    city: "", //city
+    thestate: "", //state
+    postal_code: "" //zipcode
+  }; 
+  
 $scope.componentForm = {
   street_number: 'short_name',
   route: 'long_name',
@@ -76,7 +91,22 @@ $scope.fillInAddress = function(place) {
     var addressType = place.address_components[i].types[0];
     if ($scope.componentForm[addressType]) {
       var val = place.address_components[i][$scope.componentForm[addressType]];
-      document.getElementById(addressType).value = val;
+      console.debug(addressType);
+      if(addressType == "street_number"){
+        $scope.newCustomerData.street_addy = val;
+      }
+      if(addressType == "route"){
+        $scope.newCustomerData.street_more = val;
+      }
+      if(addressType == "locality"){
+        $scope.newCustomerData.city = val;
+      }
+      if(addressType == "administrative_area_level_1"){
+        $scope.newCustomerData.thestate = val;
+      }
+      if(addressType == "postal_code"){
+        $scope.newCustomerData.postal_code = val;
+      }
     }
   }
 };

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Installation should be dead simple, you can grab a copy from bower:
 bower install ion-google-place
 ```
 
-Or clone this repository.
+Then you will need to include to appropiate files in your header
+
+```bash
+<link href="lib/ion-google-place/ion-google-place.css" rel="stylesheet">
+<script src="lib/ion-autocomplete/dist/ion-autocomplete.js"></script>
+```
 
 For the geolocation service to work, you'll need to have Google Maps javascript API somewhere in your HEAD tag:
 ```
@@ -30,5 +35,49 @@ angular.module('myApp', [
 ```
 
 That's pretty much it. Now you can use the directive like so:
-`<ion-google-place placeholder="Enter an address, Apt# and ZIP" ng-model="location" />`
+`<ion-google-place placeholder="Enter an address, Apt# and ZIP" ng-model="data.location" ng-change="googleChange()" />`
 
+There is some really important logic going on from the directive to your ionic controller. Simply using ng-model="location" will (probablly) not work. Instead use data.location and then in your view's controller you want:
+
+```javascript
+$scope.googleChange = function(){
+  console.debug($scope.data.location);
+};
+```
+
+That will allow you to grab the returned result data if you are trying to do something like the Google Maps example seen here: [https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform](https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform)
+  
+  
+If you want an angularjs version of their fillInAddress() function here is a good starting point. Put this in your views controller function, next to where you are putting $scope.googleChange();
+
+```javascript
+$scope.placeSearch = "";
+$scope.autocomplete = "";
+
+$scope.componentForm = {
+  street_number: 'short_name',
+  route: 'long_name',
+  locality: 'long_name',
+  administrative_area_level_1: 'short_name',
+  country: 'long_name',
+  postal_code: 'short_name'
+};
+
+$scope.fillInAddress = function(place) {
+ 
+  for (var component in $scope.componentForm) {
+    document.getElementById(component).value = '';
+    document.getElementById(component).disabled = false;
+  }
+
+  // Get each component of the address from the place details
+  // and fill the corresponding field on the form.
+  for (var i = 0; i < place.address_components.length; i++) {
+    var addressType = place.address_components[i].types[0];
+    if ($scope.componentForm[addressType]) {
+      var val = place.address_components[i][$scope.componentForm[addressType]];
+      document.getElementById(addressType).value = val;
+    }
+  }
+};
+```


### PR DESCRIPTION
It seems that with the latest version of Ionic, you cannot simply use ng-model="location". Instead you need to use ng-model="data.location" and set $scope.data={"location":{}}; in your controller instead of $scope.location = "";

I spent a good portion of my day pestering peeps in the Ionic IRC getting this to work. The reason is something do to with the way the variables are hashed? Or that was the prevailing theory.

Anyways, I had to get help and thats what the result was so I updated the readme. Thats what this pull request is about. I've never actually done one before but it was suggested so i thot I'd give it a try.

Thanks!
